### PR TITLE
docs: sync README and docs with current implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,243 +1,168 @@
 # Beacon — AI Agent Instructions
 
-> **Primary instructions file for all AI coding agents** (Claude, Codex, Gemini, etc.)
-> Claude Code users: `CLAUDE.md` exists at repo root and points here.
+Primary instruction file for coding agents working in this repository.
 
 ---
 
-## What Is Beacon?
+## What Beacon Is
 
-Beacon is an **open-source, local-first observability and debugging platform for AI agents**. Think "Chrome DevTools for AI Agents."
+Beacon is an open-source, local-first observability/debugging platform for AI agents.
 
-The core problem: debugging AI agents is a nightmare because existing tools only trace LLM calls, missing the full picture of what the agent does (browser clicks, file writes, shell commands). Beacon provides a **unified trace** that captures both LLM reasoning and computer-use actions in a single interactive view.
+Core idea:
+- capture LLM calls and computer-use actions in one trace
+- inspect traces in an interactive DAG
+- replay LLM steps with prompt edits
+- stream spans live over WebSocket
 
-**Key differentiators:**
-- Unified trace: LLM calls + browser actions + file ops + shell commands in one graph
-- Time-travel debugging: click any node, inspect state, edit the prompt, replay that single step
-- Local-first: zero cloud dependency, developer's machine only (for now)
-- Framework-agnostic: works with LangChain, CrewAI, custom agents via monkey-patching
-
-Full vision: `VISION.md`
-Full architecture: `docs/architecture.md`
+Reference docs:
+- Vision: `VISION.md`
+- Architecture: `docs/architecture.md`
+- API contracts: `docs/api-contracts.md`
+- Data model: `docs/data-model.md`
 
 ---
 
 ## Repo Structure
 
-```
+```text
 beacon/
-├── AGENTS.md                  # You are here (primary for Codex + all agents)
-├── CLAUDE.md                  # Claude Code reads this — points here
-├── VISION.md                  # Project vision and philosophy
-├── SECURITY.md                # Security reporting
-├── CHANGELOG.md               # Version history
-├── README.md                  # Public-facing overview
-├── LICENSE
-│
-├── .agents/                   # AI agent workflow skills
-│   └── skills/
-│       ├── review-pr/         # Phase 1: read-only PR review
-│       ├── prepare-pr/        # Phase 2: fix and prepare PR
-│       └── merge-pr/          # Phase 3: squash merge
-│
-├── .claude/commands/          # Claude Code slash commands (versioned prompts)
-│   ├── review-pr.md
-│   ├── prepare-pr.md
-│   └── merge-pr.md
-│
+├── AGENTS.md
+├── CLAUDE.md
+├── README.md
+├── CHANGELOG.md
+├── VISION.md
+├── SECURITY.md
+├── docs/
+├── backend/
+├── sdk/
+├── frontend/
+├── .agents/
+├── .claude/
 ├── .github/
-│   ├── workflows/             # CI/CD pipelines
-│   ├── ISSUE_TEMPLATE/        # Bug + feature templates
-│   └── pull_request_template.md
-│
-├── git-hooks/                 # Pre-commit hook scripts
-│   └── pre-commit
-│
-├── docs/                      # Architecture and design docs
-│   ├── architecture.md
-│   ├── data-model.md
-│   ├── api-contracts.md
-│   ├── design-system.md       # Living design system reference (colors, typography, components)
-│   ├── sdk.md
-│   ├── backend.md
-│   ├── frontend.md
-│   ├── roadmap.md
-│   └── conventions.md
-│
-├── sdk/                       # Python instrumentation SDK (pip package)
-│   ├── beacon_sdk/
-│   │   ├── __init__.py
-│   │   ├── tracer.py
-│   │   ├── decorators.py
-│   │   ├── context.py
-│   │   ├── exporters.py
-│   │   └── integrations/
-│   │       ├── langchain.py
-│   │       ├── openai.py
-│   │       ├── anthropic.py
-│   │       └── playwright.py
-│   ├── tests/
-│   └── pyproject.toml
-│
-├── backend/                   # FastAPI backend
-│   ├── app/
-│   │   ├── main.py
-│   │   ├── config.py
-│   │   ├── database.py
-│   │   ├── models.py
-│   │   ├── schemas.py
-│   │   ├── routers/
-│   │   │   ├── traces.py
-│   │   │   ├── spans.py
-│   │   │   └── replay.py
-│   │   ├── ws/
-│   │   │   └── manager.py
-│   │   └── services/
-│   └── pyproject.toml
-│
-└── frontend/                  # Vite + React UI
-    ├── src/
-    │   ├── App.tsx            # Root layout: Sidebar + page routing
-    │   ├── index.css          # Design system tokens (oklch colors, typography)
-    │   ├── components/
-    │   │   ├── ui/            # shadcn/ui (DO NOT edit)
-    │   │   ├── Sidebar/       # Persistent left sidebar navigation
-    │   │   ├── TraceList/
-    │   │   ├── TraceGraph/
-    │   │   ├── SpanDetail/
-    │   │   ├── Playground/
-    │   │   └── TimeTravel/
-    │   ├── pages/             # Page-level components
-    │   │   ├── DashboardPage.tsx
-    │   │   ├── TracesPage.tsx
-    │   │   ├── PlaygroundPage.tsx
-    │   │   └── SettingsPage.tsx
-    │   ├── lib/
-    │   │   ├── api.ts
-    │   │   ├── ws.ts
-    │   │   └── types.ts
-    │   └── store/
-    │       ├── trace.ts
-    │       ├── playground.ts
-    │       └── navigation.ts  # Page routing state
-    ├── package.json
-    └── vite.config.ts
+└── git-hooks/
 ```
+
+### Backend (`backend/`)
+- FastAPI app in `backend/app/`
+- routers: `spans`, `traces`, `replay`, `settings`, `playground`, `demo`, `stats`, `search`
+- services implement business logic
+- WebSocket manager in `backend/app/ws/manager.py`
+
+### SDK (`sdk/`)
+- package: `sdk/beacon_sdk`
+- integrations: `openai`, `anthropic`, `playwright`, `subprocess_patch`, `file_patch`, `langchain`
+
+### Frontend (`frontend/`)
+- React Router routes in `src/App.tsx`
+- pages: Dashboard, Traces, Playground, Settings
+- state: Zustand stores in `src/store/`
 
 ---
 
 ## Tech Stack
 
-| Layer | Technology | Why |
-|-------|-----------|-----|
-| SDK | Python 3.11+ | AI/ML ecosystem |
-| Backend | FastAPI + Uvicorn | Async-native, auto-docs |
-| Database | SQLite (SQLAlchemy) | Zero-config, local-first |
-| Real-time | WebSockets (FastAPI) | Live span streaming |
-| Frontend | Vite + React 18 + TypeScript | Fast dev, type safety |
-| Graph viz | React Flow (`@xyflow/react`) | Interactive graphs |
-| Code editor | Monaco Editor | VS Code quality in browser |
-| UI components | shadcn/ui + Tailwind CSS | Copy-paste, no npm bloat |
-| State | Zustand | Simpler than Redux |
-| Trace standard | OpenTelemetry (OTEL) | Industry standard |
+| Layer | Technology |
+|---|---|
+| SDK | Python 3.11+ |
+| Backend | FastAPI + SQLAlchemy + SQLite |
+| Realtime | FastAPI WebSockets |
+| Frontend | Vite + React 19 + TypeScript |
+| Graph | React Flow (`@xyflow/react`) |
+| Editor | Monaco |
+| UI primitives | shadcn/ui + Tailwind CSS |
+| State | Zustand |
 
 ---
 
 ## Core Concepts
 
 ### Span
-A single unit of work. Every agent action (LLM call, tool use, browser click, file write) produces one span.
+One unit of work. Key fields: `span_id`, `trace_id`, `parent_span_id`, `span_type`, `name`, `status`, `start_time`, `end_time`, `attributes`.
 
-Fields: `span_id`, `trace_id`, `parent_span_id`, `span_type`, `name`, `status`, `start_time`, `end_time`, `attributes`
-
-### SpanType
-```
-llm_call | tool_use | agent_step | browser_action | file_operation | shell_command | chain | custom
-```
+### Span Types
+`llm_call | tool_use | agent_step | browser_action | file_operation | shell_command | chain | custom`
 
 ### Trace
-All spans sharing a `trace_id` from one agent run. Displayed as an interactive DAG in the UI.
-
-Full schema: `docs/data-model.md`
-Full API: `docs/api-contracts.md`
+One run, grouping spans by `trace_id`.
 
 ---
 
-## Mandatory Rules (Never Violate)
+## Mandatory Rules
 
 ### Python
-- Type hints on **all** function signatures — no exceptions
-- No implicit `Any`. Import `Any` explicitly and only when type is genuinely unstructured
-- Use `|` unions (Python 3.10+), not `Optional[X]` or `Union[X, Y]`
-- Run `black` + `isort --profile black` before committing
-- Never `print()` for debugging — use `logging`
-- Tests use in-memory SQLite — never touch `~/.beacon/traces.db`
+- type hints on all function signatures
+- no implicit `Any`
+- use `|` unions
+- format with `black` + `isort --profile black`
+- no `print()` in committed code
+- backend tests use in-memory SQLite
 
 ### TypeScript
-- `strict: true` in tsconfig — no exceptions
-- No `any`. Use `unknown` + type narrowing
-- No type assertions (`as SomeType`) without an explanatory comment
-- Never `console.log()` in committed code
-- No npm installs for UI components — use `npx shadcn@latest add <component>`
+- `strict: true`
+- avoid `any`
+- avoid unexplained type assertions
+- no `console.log()` in committed code
+- do not install third-party UI component libraries; use existing shadcn/ui patterns in-repo
 
 ### Git
-- Never commit `.env` files, `__pycache__/`, `node_modules/`, `*.pyc`, `~/.beacon/traces.db`
-- Branch names: `feat/`, `fix/`, `docs/`, `refactor/` prefix
-- Commits follow Conventional Commits: `feat(sdk):`, `fix(backend):`, etc.
-- **Multi-agent safety**: do not `git stash`, do not switch branches unless explicitly asked
+- never commit secrets or local DB artifacts
+- branch names use `feat/`, `fix/`, `docs/`, `refactor/`
+- use Conventional Commits
+- multi-agent safety: do not `git stash`, do not switch branches unless requested
 
 ### Security
-- Never add API keys, passwords, or secrets to code or config files
-- Read all secrets from environment variables
-- Run `detect-secrets scan` before committing if you've added new strings
+- no hardcoded keys/secrets
+- read secrets from environment or local config files designed for that purpose
+- run `detect-secrets scan` before commit if you introduced new credential-like literals
 
 ---
 
 ## Locked-In Architecture Decisions
 
-Do not change these without updating `docs/architecture.md`:
-
-1. **SQLite only** — no PostgreSQL for MVP
-2. **No authentication** — intentional for local-first dev tool
-3. **OTEL span format** — all spans must conform to the OTEL spec
-4. **React Flow for graphs** — not D3.js directly
-5. **Monaco for code editing** — not CodeMirror or textarea
-6. **Zustand for state** — not Redux or Context API
-7. **shadcn/ui components** — copy-paste, never `npm install` component libraries
-8. **Port 7474** for backend, **5173** for frontend
+1. SQLite only for current architecture
+2. no auth layer (local-first workflow)
+3. OTEL-aligned span shape
+4. React Flow for graph rendering
+5. Monaco for prompt editing
+6. Zustand for app state
+7. shadcn/ui primitives in `components/ui/`
+8. backend `7474`, frontend `5173`
 
 ---
 
-## Running the Project
+## Run Commands
 
 ```bash
-make install          # Create venv, install all dependencies (first time)
-make dev              # Start backend + frontend (Ctrl-C to stop both)
-make stop             # Kill servers on ports 7474 and 5173
-make test             # Run all tests
-make help             # See all available targets
+make install
+make dev
+make dev-backend
+make dev-frontend
+make stop
+make test
+make lint
+make format
 ```
 
-Backend auto-docs: `http://localhost:7474/docs`
+Backend API docs: `http://localhost:7474/docs`
 
 ---
 
 ## PR Workflow (AI-Assisted)
 
-Use the `.agents/skills/` system for PRs. Three phases:
+Use `.agents/skills/` workflows for PR lifecycle tasks:
 
-1. `/review-pr` — read-only analysis, produces `review.md` + `review.json`
-2. `/prepare-pr` — fix BLOCKER/IMPORTANT findings, update CHANGELOG
-3. `/merge-pr` — squash merge with correct attribution
+1. `/review-pr` - read-only analysis and findings
+2. `/prepare-pr` - apply fixes and update docs/changelog
+3. `/merge-pr` - squash merge flow
 
-See `.agents/skills/*/SKILL.md` for full instructions per phase.
+Companion prompt files are in `.claude/commands/`.
 
 ---
 
-## Where to Start on Any Feature
+## Where To Start
 
-1. Check `docs/roadmap.md` for current phase
-2. Read the relevant design doc (`docs/backend.md`, `docs/frontend.md`, `docs/sdk.md`)
-3. Check `docs/api-contracts.md` if touching API boundaries
-4. Check `docs/data-model.md` if touching the database
-5. Follow `docs/conventions.md` for style
+1. `docs/roadmap.md`
+2. relevant subsystem doc (`docs/backend.md`, `docs/frontend.md`, `docs/sdk.md`)
+3. `docs/api-contracts.md` for API work
+4. `docs/data-model.md` for schema changes
+5. `docs/conventions.md` for style

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -1,308 +1,213 @@
 # Backend Design
 
-The `beacon-backend` is a FastAPI service that receives spans from the SDK, stores them in SQLite, and serves them to the UI via REST and WebSocket.
+`beacon-backend` is a FastAPI service that stores spans/traces in SQLite, serves debugger APIs, and streams live events over WebSocket.
 
-**Location in repo:** `backend/`
-**Runs on:** `http://localhost:7474`
+Location: `backend/`
+Runs on: `http://localhost:7474`
 
 ---
 
 ## Directory Structure
 
-```
+```text
 backend/
 ├── app/
-│   ├── main.py            # FastAPI app instance + router registration + lifespan
-│   ├── config.py          # Settings via pydantic-settings
-│   ├── database.py        # SQLAlchemy engine, session factory, Base
-│   ├── models.py          # SQLAlchemy ORM models (Trace, Span, ReplayRun)
-│   ├── schemas.py         # Pydantic v2 request/response schemas
+│   ├── main.py
+│   ├── config.py
+│   ├── database.py
+│   ├── models.py
+│   ├── schemas.py
 │   ├── routers/
-│   │   ├── __init__.py
-│   │   ├── spans.py       # POST /v1/spans, GET /v1/spans/{span_id}
-│   │   ├── traces.py      # GET /v1/traces, GET /v1/traces/{id}, GET /v1/traces/{id}/graph
-│   │   └── replay.py      # POST /v1/replay
-│   ├── ws/
-│   │   ├── __init__.py
-│   │   └── manager.py     # WebSocket connection manager + broadcaster
-│   └── services/
-│       ├── __init__.py
-│       ├── span_service.py    # Business logic for span ingestion
-│       ├── trace_service.py   # Business logic for trace queries
-│       └── replay_service.py  # Business logic for LLM replay
+│   │   ├── spans.py
+│   │   ├── traces.py
+│   │   ├── replay.py
+│   │   ├── settings.py
+│   │   ├── playground.py
+│   │   ├── demo.py
+│   │   ├── stats.py
+│   │   └── search.py
+│   ├── services/
+│   │   ├── span_service.py
+│   │   ├── trace_service.py
+│   │   ├── replay_service.py
+│   │   ├── settings_service.py
+│   │   ├── llm_client.py
+│   │   ├── playground_service.py
+│   │   ├── demo_service.py
+│   │   └── search_service.py
+│   └── ws/
+│       └── manager.py
 ├── tests/
-│   ├── conftest.py        # pytest fixtures (test db, test client)
-│   ├── test_spans.py
-│   ├── test_traces.py
-│   └── test_replay.py
 ├── pyproject.toml
 └── .env.example
 ```
 
 ---
 
-## `main.py`
+## App Bootstrap (`main.py`)
 
-```python
-from contextlib import asynccontextmanager
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
+Responsibilities:
+- initialize DB on startup (`lifespan -> init_db()`)
+- register CORS
+- include all REST routers under `/v1`
+- mount WebSocket router (`/ws/live`)
+- expose `/health`
 
-from app.database import init_db
-from app.routers import spans, traces, replay
-from app.ws.manager import ws_router
+Routers included:
+- `spans`, `traces`, `replay`, `settings`, `playground`, `demo`, `stats`, `search`
 
-@asynccontextmanager
-async def lifespan(app: FastAPI):
-    init_db()   # Create tables if they don't exist
-    yield
+---
 
-app = FastAPI(
-    title="Beacon Backend",
-    version="0.1.0",
-    lifespan=lifespan,
-)
+## Configuration (`config.py`)
 
-# CORS: Allow the Vite dev server (localhost:5173) and any localhost port
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["http://localhost:5173", "http://localhost:7474"],
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+Settings are loaded via `pydantic-settings` (`BEACON_` prefix):
+- `db_path` (default `~/.beacon/traces.db`)
+- `backend_port` (default `7474`)
+- `log_level` (default `INFO`)
 
-app.include_router(spans.router, prefix="/v1")
-app.include_router(traces.router, prefix="/v1")
-app.include_router(replay.router, prefix="/v1")
-app.include_router(ws_router)
+---
 
-@app.get("/health")
-def health():
-    from app.config import settings
-    return {"status": "ok", "version": "0.1.0", "db_path": str(settings.db_path)}
+## Database (`database.py`, `models.py`)
+
+Engine:
+- SQLite with `check_same_thread=False`
+- foreign keys explicitly enabled (`PRAGMA foreign_keys=ON`)
+
+ORM tables:
+- `traces`
+- `spans`
+- `replay_runs`
+
+Cascade behavior:
+- deleting a trace cascades to spans and replay rows
+
+---
+
+## Router Surface
+
+### Spans
+- `POST /v1/spans`
+- `GET /v1/spans/{span_id}`
+
+`POST /v1/spans`:
+- validates payload
+- upserts trace summary + span rows
+- broadcasts each persisted span over WebSocket
+
+### Traces
+- `GET /v1/traces`
+- `GET /v1/traces/{trace_id}`
+- `GET /v1/traces/{trace_id}/graph`
+- `DELETE /v1/traces/{trace_id}`
+- `DELETE /v1/traces` (batch by ids or `older_than`)
+
+### Replay
+- `POST /v1/replay`
+
+Behavior:
+- accepts only `llm_call` spans
+- merges `modified_attributes` onto stored span attributes
+- replays upstream LLM request and stores output/diff in `replay_runs`
+
+### Settings
+- `GET /v1/settings/api-keys`
+- `PUT /v1/settings/api-keys`
+- `DELETE /v1/settings/api-keys/{provider}`
+
+Keys are persisted locally in `~/.beacon/config.json` (mode `0600`).
+
+### Playground
+- `POST /v1/playground/chat`
+- `POST /v1/playground/compare`
+
+Creates real traces/spans so playground activity appears in Traces debugger.
+
+### Demo
+- `GET /v1/demo/scenarios`
+- `POST /v1/demo/run`
+
+`run` starts a background task and immediately returns `trace_id`.
+
+### Search
+- `GET /v1/search?q=...`
+
+SQLite `LIKE` search across:
+- span name
+- span attributes text
+- trace name
+
+### Stats
+- `GET /v1/stats`
+
+Returns DB file size + trace/span counts + oldest trace timestamp.
+
+---
+
+## Service Layer
+
+- `span_service.py`: ingestion/upsert logic, span response mapping
+- `trace_service.py`: list/detail/graph/delete/stats logic
+- `replay_service.py`: replay execution + persistence
+- `settings_service.py`: local API-key persistence/masking
+- `llm_client.py`: OpenAI/Anthropic HTTP calls + model/provider mapping + cost estimation
+- `playground_service.py`: chat/compare orchestration + live span broadcasting
+- `demo_service.py`: scenario catalog + async demo loop with tool-calling simulation
+- `search_service.py`: query matching + context snippets
+
+---
+
+## WebSocket (`ws/manager.py`)
+
+Endpoint: `WS /ws/live`
+
+Event types:
+- `span_created`
+- `trace_created`
+- `span_updated` (supported by manager API)
+
+Subscription model:
+- client starts in global stream (`active_connections`)
+- `subscribe_trace` moves client to trace-specific set
+- `unsubscribe_trace` returns client to global stream
+
+---
+
+## Error Semantics
+
+Common patterns:
+- `400`: invalid business request (unsupported provider, missing API key, etc.)
+- `404`: entity not found
+- `422`: request validation errors
+- `502`: upstream LLM/API failures
+
+Payload shape:
+
+```json
+{ "detail": "..." }
 ```
 
 ---
 
-## `config.py`
-
-```python
-from pathlib import Path
-from pydantic_settings import BaseSettings
-
-class Settings(BaseSettings):
-    db_path: Path = Path.home() / ".beacon" / "traces.db"
-    backend_port: int = 7474
-    log_level: str = "INFO"
-
-    class Config:
-        env_prefix = "BEACON_"
-        env_file = ".env"
-
-settings = Settings()
-```
-
-The database lives at `~/.beacon/traces.db` by default. This keeps it out of the project directory and persists across repo clones.
-
----
-
-## `database.py`
-
-```python
-from sqlalchemy import create_engine
-from sqlalchemy.orm import DeclarativeBase, sessionmaker
-from app.config import settings
-
-settings.db_path.parent.mkdir(parents=True, exist_ok=True)
-
-engine = create_engine(
-    f"sqlite:///{settings.db_path}",
-    connect_args={"check_same_thread": False},  # Required for SQLite + FastAPI
-)
-
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
-class Base(DeclarativeBase):
-    pass
-
-def init_db():
-    from app import models  # noqa: import triggers model registration
-    Base.metadata.create_all(bind=engine)
-
-def get_db():
-    """FastAPI dependency for database sessions."""
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-```
-
----
-
-## `models.py`
-
-SQLAlchemy ORM models. See `docs/data-model.md` for the full schema.
-
-```python
-from sqlalchemy import Column, Text, Float, Integer, ForeignKey
-from app.database import Base
-
-class Trace(Base):
-    __tablename__ = "traces"
-    trace_id = Column(Text, primary_key=True)
-    name = Column(Text, nullable=False)
-    start_time = Column(Float, nullable=False)
-    end_time = Column(Float)
-    span_count = Column(Integer, default=0)
-    status = Column(Text, default="unset")
-    tags = Column(Text, default="{}")
-    total_cost_usd = Column(Float, default=0)
-    total_tokens = Column(Integer, default=0)
-    created_at = Column(Float, nullable=False)
-
-class Span(Base):
-    __tablename__ = "spans"
-    span_id = Column(Text, primary_key=True)
-    trace_id = Column(Text, ForeignKey("traces.trace_id", ondelete="CASCADE"), nullable=False)
-    parent_span_id = Column(Text)
-    span_type = Column(Text, nullable=False)
-    name = Column(Text, nullable=False)
-    status = Column(Text, default="unset")
-    error_message = Column(Text)
-    start_time = Column(Float, nullable=False)
-    end_time = Column(Float)
-    attributes = Column(Text, default="{}")
-    created_at = Column(Float, nullable=False)
-
-class ReplayRun(Base):
-    __tablename__ = "replay_runs"
-    replay_id = Column(Text, primary_key=True)
-    original_span_id = Column(Text, ForeignKey("spans.span_id"), nullable=False)
-    trace_id = Column(Text, ForeignKey("traces.trace_id"), nullable=False)
-    modified_input = Column(Text, nullable=False)
-    new_output = Column(Text, nullable=False)
-    diff = Column(Text, nullable=False)
-    created_at = Column(Float, nullable=False)
-```
-
----
-
-## `schemas.py`
-
-Pydantic v2 schemas for all API request/response shapes. See `docs/api-contracts.md` for the full API spec.
-
-Key principle: **schemas are the single source of truth for the API shape.** The frontend's `types.ts` must mirror these exactly.
-
----
-
-## Routers
-
-### `routers/spans.py`
-
-Handles span ingestion (`POST /v1/spans`) and span detail (`GET /v1/spans/{span_id}`).
-
-On span ingestion:
-1. Validate the incoming spans with Pydantic
-2. Upsert the parent `Trace` row (create if new, update `end_time` / `span_count` if existing)
-3. Insert the `Span` rows
-4. Update `Trace.total_cost_usd` and `Trace.total_tokens` if the span has LLM attributes
-5. Broadcast each span to connected WebSocket clients via `ws_manager.broadcast()`
-
-### `routers/traces.py`
-
-Handles trace list (`GET /v1/traces`) and trace detail + graph endpoints.
-
-The `/graph` endpoint transforms the flat span list into React Flow nodes and edges. Node positions are all `{x: 0, y: 0}` — layout is done client-side.
-
-### `routers/replay.py`
-
-Handles `POST /v1/replay`.
-
-1. Fetch the original span
-2. Validate it's a `llm_call` span
-3. Parse the original `llm.prompt` and `llm.provider` / `llm.model` from attributes
-4. Merge `modified_attributes` over original attributes
-5. Call the appropriate LLM API (OpenAI or Anthropic) using the developer's API key from environment
-6. Build a diff of old vs. new completion
-7. Store the replay result in `replay_runs`
-8. Return the result
-
-**Security note:** The replay endpoint uses `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` from the server's environment. It does not accept API keys from the HTTP request.
-
----
-
-## WebSocket Manager
-
-```
-ws/manager.py
-```
-
-Manages active WebSocket connections. Uses a simple in-memory set.
-
-```python
-class ConnectionManager:
-    def __init__(self):
-        self.active_connections: set[WebSocket] = set()
-        self.trace_subscriptions: dict[str, set[WebSocket]] = {}  # trace_id → set of sockets
-
-    async def connect(self, ws: WebSocket):
-        await ws.accept()
-        self.active_connections.add(ws)
-
-    def disconnect(self, ws: WebSocket):
-        self.active_connections.discard(ws)
-        for sockets in self.trace_subscriptions.values():
-            sockets.discard(ws)
-
-    async def broadcast_span(self, span_dict: dict):
-        """Broadcast to all connections watching this trace."""
-        trace_id = span_dict["trace_id"]
-        targets = self.trace_subscriptions.get(trace_id, set()) | self.active_connections
-        for ws in list(targets):
-            try:
-                await ws.send_json({"event": "span_created", "span": span_dict})
-            except Exception:
-                self.disconnect(ws)
-
-ws_manager = ConnectionManager()  # Singleton
-```
-
----
-
-## Running the Backend
+## Run + Test
 
 ```bash
-cd backend
-python -m venv .venv
-source .venv/bin/activate
-pip install -e ".[dev]"
+# from repo root
+make install
+make dev-backend
 
-# Development (with hot reload)
-uvicorn app.main:app --reload --port 7474
-
-# Production (MVP local)
-uvicorn app.main:app --port 7474
+# tests
+make test
+# or
+backend/.venv/bin/pytest backend/tests -v
 ```
 
-Auto-generated API docs: `http://localhost:7474/docs`
+OpenAPI docs: `http://localhost:7474/docs`
 
 ---
 
-## Testing
+## Constraints
 
-```bash
-cd backend
-pytest tests/ -v
-```
-
-Tests use an in-memory SQLite database via a `conftest.py` fixture that overrides the database dependency. Never use the real `~/.beacon/traces.db` in tests.
-
----
-
-## Key Constraints
-
-- **SQLite only:** Do not introduce any other database. SQLite handles concurrent reads well. Concurrent writes are serialized by SQLite automatically.
-- **No authentication:** No JWT, no sessions, no API keys required. The backend trusts all local connections.
-- **No external services except LLM replay:** The backend only calls external APIs during `/v1/replay`, and only uses keys from the server environment.
-- **Port 7474:** Do not change the default port. It is used throughout the codebase and documentation.
+- SQLite only for current architecture
+- no auth layer by design (local-first developer workflow)
+- no external infra (queues/brokers) required
+- fixed default backend port: `7474`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,61 +11,55 @@
 ```bash
 git clone https://github.com/vexorlabs/beacon
 cd beacon
-make install   # creates venv, installs backend + SDK + frontend deps
-make dev       # starts backend (:7474) and frontend (:5173)
+make install
+make dev
 ```
 
-Open [http://localhost:5173](http://localhost:5173) to see the UI.
+Open `http://localhost:5173`.
 
-## Project Structure
+## Common Commands
 
-```
-backend/    Python/FastAPI backend + SQLite database
-sdk/        beacon-sdk Python package (instrumentation + integrations)
-frontend/   React/TypeScript UI (Vite, React Flow, Monaco)
-docs/       Architecture, API contracts, data model, conventions
-```
-
-## Development
-
-| Command | What it does |
+| Command | Purpose |
 |---|---|
-| `make dev` | Start backend + frontend together |
-| `make dev-backend` | Backend only (port 7474) |
-| `make dev-frontend` | Frontend only (port 5173) |
-| `make stop` | Kill both servers |
-| `make test` | Run backend + SDK pytest tests |
-| `make lint` | Check formatting (black, isort, eslint) |
-| `make format` | Auto-format Python code |
-| `make db-reset` | Delete `~/.beacon/traces.db` |
-| `make clean` | Remove venvs, node_modules, build artifacts |
+| `make dev` | backend + frontend |
+| `make dev-backend` | backend only (`7474`) |
+| `make dev-frontend` | frontend only (`5173`) |
+| `make stop` | stop dev servers |
+| `make test` | backend + sdk tests |
+| `make lint` | black/isort/eslint checks |
+| `make format` | black + isort autofix |
+| `make db-reset` | delete `~/.beacon/traces.db` |
 
-The SDK is installed in editable mode (`pip install -e`), so changes to `sdk/` are picked up immediately.
+## Branch + Commit Conventions
+
+- Branch prefixes: `feat/`, `fix/`, `docs/`, `refactor/`
+- Conventional commits: `feat(backend): ...`, `fix(frontend): ...`, etc.
 
 ## Code Style
 
-**Python:**
-- Formatted with `black` + `isort` (run `make format`)
-- Type hints on all function signatures — no implicit `Any`
-- No `print()` statements in committed code (use `logging`)
+Python:
+- type hints on all signatures
+- `black` + `isort --profile black`
+- use `logging`, not `print()`
 
-**TypeScript:**
-- `strict: true` in tsconfig
-- No `any` types
-- No `console.log` in committed code
+TypeScript:
+- strict typing (`strict: true`)
+- avoid `any`
+- no `console.log()` in committed code
 
-See [conventions.md](./conventions.md) for the full style guide.
+See `docs/conventions.md` for full details.
 
-## PR Guidelines
+## Security + Safety
 
-1. **Branch naming:** `username/short-description`
-2. **Commit messages:** Conventional Commits style (`feat:`, `fix:`, `docs:`, `refactor:`)
-3. **Tests pass:** `make test` must pass before submitting
-4. **No secrets:** Never commit `.env`, API keys, or `~/.beacon/traces.db`
+- never commit secrets or `.env`
+- never commit `~/.beacon/traces.db`
+- prefer in-memory SQLite for tests
 
-## Further Reading
+## Useful Docs
 
-- [Architecture](./architecture.md) — system design and data flow
-- [Data Model](./data-model.md) — database schema
-- [API Contracts](./api-contracts.md) — REST and WebSocket specs
-- [Conventions](./conventions.md) — full code style guide
+- `docs/architecture.md`
+- `docs/api-contracts.md`
+- `docs/data-model.md`
+- `docs/backend.md`
+- `docs/frontend.md`
+- `docs/sdk.md`

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,235 +1,99 @@
 # Coding Conventions
 
-This document defines the rules all code in this repo must follow. AI coding assistants should read this before writing any code.
+Repository-wide style and workflow rules.
 
 ---
 
-## General Rules (All Languages)
+## General Rules
 
-1. **No debug output in committed code.** Remove all `print()`, `console.log()`, and similar before committing.
-2. **No commented-out code.** Delete it. Git history preserves old code.
-3. **No magic numbers.** Extract constants with names.
-4. **Names must be explicit.** `span_start_time` not `t`. `handle_span_created` not `handler`.
-5. **Errors must be handled.** Never silently swallow exceptions (except in the SDK exporter, which is explicitly documented to do so).
-6. **No `.env` files committed.** Use `.env.example` with placeholder values.
-7. **No API keys in code.** Read them from environment variables.
+1. No debug noise in committed code (`print`, `console.log`, commented-out blocks).
+2. Use explicit names.
+3. Handle errors intentionally.
+4. Never commit secrets, `.env`, or local DB artifacts.
 
 ---
 
 ## Python (SDK + Backend)
 
 ### Formatting
-- **Formatter:** `black` with default settings (88-char line length)
-- **Import sorter:** `isort` with `--profile black`
-- Run both before every commit
+- `black` (line length 88)
+- `isort --profile black`
 
-### Type Hints
-- Type hints on **all** function signatures (parameters + return type)
-- Use `from __future__ import annotations` at the top of files for forward references
-- No implicit `Any`. Use `object` if type is truly unknown. Use `dict[str, Any]` with an explicit `Any` import only when the value type is genuinely unstructured (e.g., OTEL attributes)
-- Use `|` syntax for unions (Python 3.10+), not `Optional[X]` or `Union[X, Y]`
+### Typing
+- type hints on all function signatures
+- no implicit `Any`
+- prefer `|` unions over `Optional`/`Union`
 
-```python
-# Good
-def create_span(span_id: str, parent_id: str | None = None) -> Span:
+### Backend Structure
+- routers handle HTTP concerns only
+- service layer handles business logic and DB access
+- SQLAlchemy 2.x patterns (`select`, sessions passed in)
 
-# Bad
-def create_span(span_id, parent_id=None):
-```
-
-### Naming
-| Thing | Convention | Example |
-|-------|-----------|---------|
-| Files | `snake_case` | `span_service.py` |
-| Classes | `PascalCase` | `BeaconTracer` |
-| Functions | `snake_case` | `get_current_span` |
-| Variables | `snake_case` | `trace_id` |
-| Constants | `UPPER_SNAKE_CASE` | `DEFAULT_BACKEND_URL` |
-| Private | `_leading_underscore` | `_active_spans` |
-
-### Classes vs Functions
-- Prefer functions for stateless operations
-- Use classes when there is meaningful state to encapsulate (`BeaconTracer`, `ConnectionManager`)
-- Do not use classes purely as namespaces; use modules instead
-
-### Pydantic Models (Backend Schemas)
-- All request/response schemas in `schemas.py` are Pydantic v2 models
-- Use `model_config = ConfigDict(...)` not inner `Config` class (Pydantic v2 style)
-- Validators use `@field_validator` (v2 style), not `@validator`
-
-### FastAPI Routers
-- One router file per top-level resource: `spans.py`, `traces.py`, `replay.py`
-- All router functions are `async`
-- Use `Annotated[Session, Depends(get_db)]` for dependency injection
-- Return Pydantic response models explicitly (enables OpenAPI docs)
-
-```python
-# Good
-@router.get("/{trace_id}", response_model=TraceDetailResponse)
-async def get_trace(
-    trace_id: str,
-    db: Annotated[Session, Depends(get_db)],
-) -> TraceDetailResponse:
-    ...
-
-# Bad
-@router.get("/{trace_id}")
-def get_trace(trace_id, db=Depends(get_db)):
-    ...
-```
-
-### SQLAlchemy
-- Use SQLAlchemy 2.0 style (`select()` not `query()`)
-- Pass `db` sessions into service functions; do not create sessions inside services
-- All database writes use explicit transactions
-
-### Testing (pytest)
-- Test files: `test_<module>.py`
-- Test functions: `test_<what>_<condition>_<expectation>()`
-- Use `pytest.fixture` for shared setup
-- Use in-memory SQLite for all tests (`sqlite:///:memory:`)
-- Never hit the network in tests; mock external calls with `pytest-mock` or `responses`
-
-```python
-# Good test name
-def test_create_span_with_missing_trace_id_raises_validation_error():
-
-# Bad test name
-def test_span():
-```
+### Tests
+- pytest
+- in-memory SQLite for backend tests
+- mock external network calls
 
 ---
 
 ## TypeScript (Frontend)
 
-### Formatting
-- **Formatter:** Prettier with default settings
-- **Linter:** ESLint with `eslint-config-react-app` or the Vite default config
-- Both run on save via editor settings and on CI
-
 ### Type Safety
-- `strict: true` in `tsconfig.json`. No exceptions.
-- No `any`. Use `unknown` + type narrowing when type is uncertain.
-- No type assertions (`as SomeType`) unless there is a comment explaining why it's safe.
-- Prefer `interface` over `type` for object shapes that represent entities.
-- Use `type` for unions, intersections, and computed types.
+- `strict: true`
+- avoid `any`
+- document unavoidable type assertions
 
-```typescript
-// Good
-interface Span {
-  span_id: string;
-  span_type: SpanType;
-}
+### Architecture
+- route-level composition in `pages/`
+- shared app state in Zustand stores (`store/*`)
+- API access centralized in `lib/api.ts`
+- WebSocket access centralized in `lib/ws.ts`
 
-type SpanType = "llm_call" | "tool_use" | "browser_action";
-
-// Bad
-const span = response as any;
-```
-
-### Naming
-| Thing | Convention | Example |
-|-------|-----------|---------|
-| Files (components) | `PascalCase` | `TraceGraph.tsx` |
-| Files (utilities) | `camelCase` | `api.ts` |
-| React components | `PascalCase` | `TraceList` |
-| Hooks | `useCamelCase` | `useGraphLayout` |
-| Variables | `camelCase` | `selectedSpanId` |
-| Constants | `UPPER_SNAKE_CASE` | `BASE_URL` |
-| Interfaces | `PascalCase` | `Span`, `TraceSummary` |
-| Type aliases | `PascalCase` | `SpanType` |
-
-### React Components
-- One component per file (except small, tightly coupled sub-components)
-- Component folder structure: `ComponentName/index.tsx` for the main component
-- Props interfaces defined in the same file, named `ComponentNameProps`
-- Export the component as the default export
-
-```typescript
-// TraceList/index.tsx
-interface TraceListProps {
-  traces: TraceSummary[];
-  onSelectTrace: (traceId: string) => void;
-}
-
-export default function TraceList({ traces, onSelectTrace }: TraceListProps) {
-  ...
-}
-```
-
-### Hooks
-- All data fetching via custom hooks, not directly in components
-- State that is shared between components goes in the Zustand store
-- Local state (UI-only, not shared) stays in `useState` within the component
-
-### shadcn/ui Components
-- Never edit files in `src/components/ui/`. If you need to customize, copy the component out and rename it.
-- Add new shadcn components with `npx shadcn@latest add <component>`.
-
-### Imports
-- Use absolute imports via `"paths"` in `tsconfig.json` (e.g., `import { Span } from "@/lib/types"`)
-- Order: React → third-party → local (enforced by ESLint import plugin)
+### Components
+- feature components in `components/<Feature>/`
+- `components/ui/` is reserved for shadcn/ui primitives
+- avoid editing shadcn primitives directly unless intentional and repo-wide
 
 ### Error Handling
-- All `fetch` calls must handle errors (check `res.ok`, catch network errors)
-- Display user-facing errors via toast notifications (use shadcn `sonner` or `toast`)
-- Never `console.error` in production code paths — handle the error or surface it to the user
+- normalize HTTP errors in API client
+- surface user-relevant failures in UI state/components
 
 ---
 
 ## Git Conventions
 
-### Branch Names
-- `feat/<short-description>` — New feature
-- `fix/<short-description>` — Bug fix
-- `docs/<short-description>` — Documentation only
-- `refactor/<short-description>` — Refactoring, no new behavior
+### Branch Prefixes
+- `feat/`
+- `fix/`
+- `docs/`
+- `refactor/`
 
-### Commit Messages
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
+### Commits
+Use Conventional Commits:
 
-```
-<type>(<scope>): <short description>
-
-[optional body]
-```
-
-Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
-Scopes: `sdk`, `backend`, `frontend`, `deps`
-
-Examples:
-```
-feat(sdk): add @observe decorator with async support
-fix(backend): handle duplicate span_id on ingestion
-docs(frontend): document React Flow layout approach
+```text
+feat(sdk): add replay helper
+fix(backend): handle unknown provider
+docs(frontend): update router docs
 ```
 
-### What NOT to Commit
-- `.env` files
-- `__pycache__/`
+---
+
+## Do Not Commit
+
+- `.env`
 - `node_modules/`
+- `__pycache__/`
 - `*.pyc`
-- `~/.beacon/traces.db` (the live database)
-- IDE config (`.vscode/`, `.idea/`) — these go in `.gitignore`
+- `~/.beacon/traces.db`
 
 ---
 
-## File Organization Rules
+## Locked Decisions (MVP)
 
-- No business logic in router files. Routers call service functions.
-- No database queries in service files — pass `db` session in as a parameter.
-- No imports between `sdk/` and `backend/` — they are independent packages.
-- No imports between `frontend/` and `backend/` — they communicate only via HTTP/WebSocket.
-
----
-
-## Do Not
-
-- Do not add a new database (SQLite only for MVP)
-- Do not add authentication (no-auth is a feature for local dev tool)
-- Do not use `print()` for debugging in committed code (use `logging`)
-- Do not use `console.log()` in committed frontend code
-- Do not install npm packages for UI components (use shadcn copy-paste)
-- Do not use `any` in TypeScript
-- Do not skip type hints in Python
-- Do not add external API calls to the backend (except LLM APIs in the replay service)
+- SQLite only
+- no authentication layer
+- React Flow for graph rendering
+- Monaco for prompt editing
+- Zustand for client state
+- backend port `7474`, frontend port `5173`

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,271 +1,211 @@
 # Data Model
 
-This document defines the trace schema (OTEL-based) and the SQLite database schema. This is the source of truth for how trace data is structured throughout the system.
+This document defines Beacon's persisted schema and span attribute conventions.
 
 ---
 
 ## Core Concepts
 
 ### Trace
-A complete agent execution run. All spans from one agent run share the same `trace_id`. A trace is derived, not stored directly — it is the set of all spans with a given `trace_id`.
+A trace is one agent run, identified by `trace_id`.
+
+In code, trace summary rows are persisted in `traces` (not purely derived at read-time).
 
 ### Span
-A single unit of work. Every observable action the agent takes — an LLM call, a tool invocation, a browser click — produces one span. Spans are the atomic unit of storage.
+A span is one unit of work (LLM call, tool use, browser action, etc.).
 
-### Span Tree
-Spans have a `parent_span_id` that forms a tree (technically a DAG when replay spans are included). The root span has no parent. The graph visualizer renders this tree.
+### Replay Run
+A replay run stores output/diff for a replayed `llm_call` span.
 
 ---
 
 ## Span Schema
 
-### Core Fields (Required on All Spans)
-
 ```python
 class Span:
-    # Identity
-    span_id: str          # UUID v4, unique per span
-    trace_id: str         # UUID v4, same for all spans in one agent run
-    parent_span_id: str | None  # UUID v4 of parent span, None for root
+    span_id: str
+    trace_id: str
+    parent_span_id: str | None
 
-    # Timing
-    start_time: float     # Unix timestamp (seconds, float for sub-second precision)
-    end_time: float | None  # None while span is in progress
+    span_type: SpanType
+    name: str
+    status: SpanStatus
+    error_message: str | None
 
-    # Classification
-    span_type: SpanType   # Enum (see below)
-    name: str             # Human-readable label (e.g., "openai.chat.completions")
-    status: SpanStatus    # Enum: ok | error | unset
+    start_time: float
+    end_time: float | None
 
-    # Optional
-    error_message: str | None  # Set when status == error
-    attributes: dict[str, Any]  # Type-specific metadata (see below)
+    attributes: dict[str, Any]
 ```
 
-### SpanType Enum
+### `SpanType`
 
-```python
-class SpanType(str, Enum):
-    LLM_CALL        = "llm_call"        # LLM API call
-    TOOL_USE        = "tool_use"        # Tool/function invocation
-    AGENT_STEP      = "agent_step"      # Logical agent reasoning step
-    BROWSER_ACTION  = "browser_action"  # Playwright/Selenium action
-    FILE_OPERATION  = "file_operation"  # File read/write/delete
-    SHELL_COMMAND   = "shell_command"   # subprocess call
-    CHAIN           = "chain"           # LangChain chain execution
-    CUSTOM          = "custom"          # Developer-defined
+```text
+llm_call | tool_use | agent_step | browser_action | file_operation | shell_command | chain | custom
 ```
 
-### SpanStatus Enum
+### `SpanStatus`
 
-```python
-class SpanStatus(str, Enum):
-    OK      = "ok"       # Completed successfully
-    ERROR   = "error"    # Threw an exception
-    UNSET   = "unset"    # In progress (span not yet ended)
+```text
+ok | error | unset
 ```
 
 ---
 
-## Span Attributes by Type
+## Attribute Conventions
 
-Attributes are stored as JSON in the `attributes` column. The structure depends on `span_type`.
+### `llm_call`
 
-### `llm_call` Attributes
+Common keys:
+- `llm.provider` (string)
+- `llm.model` (string)
+- `llm.prompt` (JSON string)
+- `llm.completion` (string)
+- `llm.tokens.input` / `llm.tokens.output` / `llm.tokens.total` (number)
+- `llm.cost_usd` (number)
+- `llm.temperature` (number, optional)
+- `llm.max_tokens` (number, optional)
+- `llm.finish_reason` (string, optional)
+- `llm.tool_calls` (JSON string, optional)
 
-```python
-{
-    "llm.provider":        str,          # "openai" | "anthropic" | "google" | ...
-    "llm.model":           str,          # "gpt-4o" | "claude-3-7-sonnet" | ...
-    "llm.prompt":          str,          # Full prompt text (system + user messages as JSON string)
-    "llm.completion":      str,          # Full completion text
-    "llm.tokens.input":    int,          # Input token count
-    "llm.tokens.output":   int,          # Output token count
-    "llm.tokens.total":    int,          # Sum of above
-    "llm.cost_usd":        float,        # Estimated cost in USD
-    "llm.temperature":     float | None, # Temperature if set
-    "llm.max_tokens":      int | None,   # Max tokens if set
-    "llm.stop_sequences":  list[str] | None,
-    "llm.finish_reason":   str,          # "stop" | "length" | "tool_calls" | ...
-    "llm.tool_calls":      list | None,  # If model called tools
-}
-```
+### `tool_use`
 
-### `tool_use` Attributes
+Common keys:
+- `tool.name`
+- `tool.input`
+- `tool.output`
+- `tool.framework` (optional)
 
-```python
-{
-    "tool.name":        str,   # Name of the tool (e.g., "search_web", "read_file")
-    "tool.input":       str,   # JSON string of tool input parameters
-    "tool.output":      str,   # JSON string of tool output
-    "tool.framework":   str,   # "langchain" | "crewai" | "custom"
-}
-```
+### `browser_action`
 
-### `browser_action` Attributes
+Common keys:
+- `browser.action`
+- `browser.url`
+- `browser.selector` (optional)
+- `browser.value` (optional)
+- `browser.page_title` (optional)
+- `browser.screenshot` (optional base64 PNG string)
 
-```python
-{
-    "browser.action":       str,          # "navigate" | "click" | "type" | "screenshot" | "wait" | ...
-    "browser.url":          str,          # Current page URL at time of action
-    "browser.selector":     str | None,   # CSS selector or XPath if applicable
-    "browser.value":        str | None,   # Text typed, if action == "type"
-    "browser.screenshot":   str | None,   # Base64-encoded PNG screenshot (optional, can be large)
-    "browser.page_title":   str | None,
-}
-```
+### `file_operation`
 
-### `file_operation` Attributes
+Common keys:
+- `file.operation`
+- `file.path`
+- `file.size_bytes` (optional)
+- `file.content` (optional/truncated)
 
-```python
-{
-    "file.operation":   str,          # "read" | "write" | "append" | "delete" | "exists"
-    "file.path":        str,          # Absolute or relative file path
-    "file.size_bytes":  int | None,
-    "file.content":     str | None,   # File content snippet (truncated to 2000 chars)
-}
-```
+### `shell_command`
 
-### `shell_command` Attributes
+Common keys:
+- `shell.command`
+- `shell.returncode`
+- `shell.stdout` (optional/truncated)
+- `shell.stderr` (optional/truncated)
 
-```python
-{
-    "shell.command":     str,          # The full command string
-    "shell.args":        list[str],    # Parsed argument list
-    "shell.cwd":         str | None,   # Working directory
-    "shell.exit_code":   int | None,   # Return code
-    "shell.stdout":      str | None,   # Stdout (truncated to 4000 chars)
-    "shell.stderr":      str | None,   # Stderr (truncated to 4000 chars)
-    "shell.env":         dict | None,  # Environment variable overrides
-}
-```
+### `agent_step`
 
-### `agent_step` Attributes
+Common keys:
+- `agent.framework`
+- `agent.step_name`
+- `agent.input`
+- `agent.output`
+- `agent.thought`
 
-```python
-{
-    "agent.framework":  str,          # "langchain" | "crewai" | "autogen" | "custom"
-    "agent.step_name":  str,          # Human-readable step name
-    "agent.input":      str | None,   # Step input (JSON string)
-    "agent.output":     str | None,   # Step output (JSON string)
-    "agent.thought":    str | None,   # Agent's reasoning/thought (if available)
-}
-```
+### `chain`
 
-### `chain` Attributes (LangChain-specific)
-
-```python
-{
-    "chain.type":       str,   # LangChain chain class name
-    "chain.input":      str,   # JSON string
-    "chain.output":     str,   # JSON string
-}
-```
+Common keys:
+- `chain.type`
+- `chain.input`
+- `chain.output`
 
 ---
 
-## SQLite Database Schema
+## SQLite Schema
 
-Database file: `~/.beacon/traces.db` (created automatically on first run)
+DB path default: `~/.beacon/traces.db`
 
-### `traces` Table
+### `traces`
 
-Stores one row per unique trace (agent run).
+Stores per-trace summary fields.
 
 ```sql
 CREATE TABLE traces (
-    trace_id        TEXT PRIMARY KEY,     -- UUID v4
-    name            TEXT NOT NULL,        -- Human-readable label (first span's name or agent name)
-    start_time      REAL NOT NULL,        -- Unix timestamp of first span
-    end_time        REAL,                 -- Unix timestamp of last span (NULL if in progress)
-    span_count      INTEGER DEFAULT 0,    -- Total number of spans in this trace
-    status          TEXT DEFAULT 'unset', -- 'ok' | 'error' | 'unset'
-    tags            TEXT DEFAULT '{}',    -- JSON object of user-defined tags
-    total_cost_usd  REAL DEFAULT 0,       -- Sum of all llm.cost_usd in trace
-    total_tokens    INTEGER DEFAULT 0,    -- Sum of all llm.tokens.total in trace
-    created_at      REAL NOT NULL         -- Insert timestamp (for sorting)
+  trace_id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  start_time REAL NOT NULL,
+  end_time REAL,
+  span_count INTEGER DEFAULT 0,
+  status TEXT DEFAULT 'unset',
+  tags TEXT DEFAULT '{}',
+  total_cost_usd REAL DEFAULT 0,
+  total_tokens INTEGER DEFAULT 0,
+  created_at REAL NOT NULL
 );
-
-CREATE INDEX idx_traces_created_at ON traces (created_at DESC);
-CREATE INDEX idx_traces_status ON traces (status);
 ```
 
-### `spans` Table
+Indexes:
+- `idx_traces_created_at`
+- `idx_traces_status`
 
-Stores one row per span.
+### `spans`
 
 ```sql
 CREATE TABLE spans (
-    span_id         TEXT PRIMARY KEY,     -- UUID v4
-    trace_id        TEXT NOT NULL,        -- References traces.trace_id
-    parent_span_id  TEXT,                 -- References spans.span_id (NULL for root)
-    span_type       TEXT NOT NULL,        -- SpanType enum value
-    name            TEXT NOT NULL,        -- Human-readable label
-    status          TEXT DEFAULT 'unset', -- SpanStatus enum value
-    error_message   TEXT,                 -- NULL unless status == 'error'
-    start_time      REAL NOT NULL,        -- Unix timestamp (float)
-    end_time        REAL,                 -- NULL while in progress
-    attributes      TEXT DEFAULT '{}',    -- JSON object of type-specific attributes
-    created_at      REAL NOT NULL,        -- Insert timestamp
-
-    FOREIGN KEY (trace_id) REFERENCES traces (trace_id) ON DELETE CASCADE
+  span_id TEXT PRIMARY KEY,
+  trace_id TEXT NOT NULL REFERENCES traces(trace_id) ON DELETE CASCADE,
+  parent_span_id TEXT,
+  span_type TEXT NOT NULL,
+  name TEXT NOT NULL,
+  status TEXT DEFAULT 'unset',
+  error_message TEXT,
+  start_time REAL NOT NULL,
+  end_time REAL,
+  attributes TEXT DEFAULT '{}',
+  created_at REAL NOT NULL
 );
-
-CREATE INDEX idx_spans_trace_id ON spans (trace_id);
-CREATE INDEX idx_spans_parent_span_id ON spans (parent_span_id);
-CREATE INDEX idx_spans_span_type ON spans (span_type);
-CREATE INDEX idx_spans_start_time ON spans (start_time);
-CREATE INDEX idx_spans_name ON spans (name);
 ```
 
-### `replay_runs` Table
+Indexes:
+- `idx_spans_trace_id`
+- `idx_spans_parent_span_id`
+- `idx_spans_span_type`
+- `idx_spans_start_time`
+- `idx_spans_name`
 
-Stores the result of replay operations (when a developer edits a prompt and re-runs a step).
+### `replay_runs`
 
 ```sql
 CREATE TABLE replay_runs (
-    replay_id           TEXT PRIMARY KEY,  -- UUID v4
-    original_span_id    TEXT NOT NULL,     -- References spans.span_id
-    trace_id            TEXT NOT NULL,     -- References traces.trace_id
-    modified_input      TEXT NOT NULL,     -- JSON: what was changed
-    new_output          TEXT NOT NULL,     -- JSON: what the new output was
-    diff                TEXT NOT NULL,     -- JSON: diff between old and new output
-    created_at          REAL NOT NULL,
-
-    FOREIGN KEY (original_span_id) REFERENCES spans (span_id) ON DELETE CASCADE,
-    FOREIGN KEY (trace_id) REFERENCES traces (trace_id) ON DELETE CASCADE
+  replay_id TEXT PRIMARY KEY,
+  original_span_id TEXT NOT NULL REFERENCES spans(span_id) ON DELETE CASCADE,
+  trace_id TEXT NOT NULL REFERENCES traces(trace_id) ON DELETE CASCADE,
+  modified_input TEXT NOT NULL,
+  new_output TEXT NOT NULL,
+  diff TEXT NOT NULL,
+  created_at REAL NOT NULL
 );
 ```
 
 ---
 
-## Computed / Derived Fields
+## Derived Fields
 
-These are not stored but are computed on read:
+Derived on read:
+- `duration_ms = (end_time - start_time) * 1000` for spans/traces when `end_time` exists
 
-| Field | Computed From | Used In |
-|-------|--------------|---------|
-| `duration_ms` | `(end_time - start_time) * 1000` | API responses, UI |
-| `child_spans` | `SELECT * FROM spans WHERE parent_span_id = ?` | Graph building |
-| `trace.status` | Worst status of all spans (error > unset > ok) | Trace list |
-
----
-
-## Trace ID Generation
-
-The SDK generates a `trace_id` at the start of each agent run using `uuid.uuid4()`. Spans within that run share the same `trace_id`. The SDK stores the active `trace_id` in Python's `contextvars.ContextVar` to propagate it across async boundaries.
+Trace status logic in service layer:
+- `error` dominates
+- then `unset`
+- else `ok`
 
 ---
 
-## Size Limits
+## Size Guards (SDK)
 
-To prevent the database from growing unboundedly, the SDK enforces these limits before sending:
-
-| Field | Limit | Behavior on Exceed |
-|-------|-------|-------------------|
-| `llm.prompt` | 50,000 chars | Truncated with `[TRUNCATED]` suffix |
-| `llm.completion` | 50,000 chars | Truncated |
-| `file.content` | 2,000 chars | Truncated |
-| `shell.stdout` | 4,000 chars | Truncated |
-| `shell.stderr` | 4,000 chars | Truncated |
-| `browser.screenshot` | 500 KB (base64) | Dropped (attribute set to null) |
+SDK truncation limits (`beacon_sdk.models`):
+- `llm.prompt`: 50,000 chars
+- `llm.completion`: 50,000 chars
+- `file.content`: 2,000 chars
+- `shell.stdout`: 4,000 chars
+- `shell.stderr`: 4,000 chars
+- `browser.screenshot`: dropped when base64 string exceeds configured max bytes

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,358 +1,222 @@
 # Frontend Design
 
-The `beacon-ui` is a Vite + React + TypeScript application. It is the developer's primary interface for viewing and debugging agent traces.
+`beacon-ui` is a React + TypeScript app (Vite) for interactive trace debugging.
 
-**Location in repo:** `frontend/`
-**Runs on:** `http://localhost:5173` (Vite default)
-**Communicates with:** `beacon-backend` at `http://localhost:7474`
+Location: `frontend/`
+Runs on: `http://localhost:5173`
+Backend: proxied to `http://localhost:7474`
+
+---
+
+## Tech Snapshot
+
+- React 19
+- React Router 7
+- Zustand 5
+- React Flow (`@xyflow/react`)
+- Monaco (`@monaco-editor/react`)
+- Tailwind CSS 4 + shadcn/ui
 
 ---
 
 ## Directory Structure
 
-```
+```text
 frontend/
 ├── src/
-│   ├── main.tsx                    # React entry point
-│   ├── App.tsx                     # Root layout: Sidebar + page routing
-│   ├── index.css                   # Design system tokens (oklch colors, typography, spacing)
-│   │
+│   ├── main.tsx
+│   ├── App.tsx
+│   ├── index.css
+│   ├── pages/
+│   │   ├── DashboardPage.tsx
+│   │   ├── TracesPage.tsx
+│   │   ├── PlaygroundPage.tsx
+│   │   └── SettingsPage.tsx
 │   ├── components/
-│   │   ├── ui/                     # shadcn/ui copy-pasted components (DO NOT edit)
-│   │   │   ├── button.tsx
-│   │   │   ├── badge.tsx
-│   │   │   ├── separator.tsx
-│   │   │   └── ...
-│   │   │
-│   │   ├── Sidebar/                # Persistent left sidebar navigation
-│   │   │   └── index.tsx
-│   │   │
-│   │   ├── TraceList/              # Trace list panel (used in TracesPage)
-│   │   │   ├── index.tsx
-│   │   │   ├── TraceListItem.tsx
-│   │   │   └── TraceFilter.tsx
-│   │   │
-│   │   ├── TraceGraph/             # Graph panel (used in TracesPage)
-│   │   │   ├── index.tsx
-│   │   │   ├── SpanNode.tsx
-│   │   │   └── useGraphLayout.ts
-│   │   │
-│   │   ├── SpanDetail/             # Span detail panel (used in TracesPage)
-│   │   │   ├── index.tsx
-│   │   │   ├── LlmCallDetail.tsx
-│   │   │   ├── ToolUseDetail.tsx
-│   │   │   ├── BrowserDetail.tsx
-│   │   │   ├── PromptEditor.tsx
-│   │   │   └── ReplayPanel.tsx
-│   │   │
-│   │   ├── Playground/             # Chat + Compare mode components
-│   │   │   ├── index.tsx
-│   │   │   ├── ChatPanel.tsx
-│   │   │   ├── CompareView.tsx
-│   │   │   ├── MessageBubble.tsx
-│   │   │   └── ModelSelector.tsx
-│   │   │
-│   │   └── TimeTravel/             # Time-travel slider
-│   │       └── index.tsx
-│   │
-│   ├── pages/                      # Page-level components
-│   │   ├── DashboardPage.tsx       # Getting-started guide + stats overview
-│   │   ├── TracesPage.tsx          # 3-panel debugger layout
-│   │   ├── PlaygroundPage.tsx      # Playground wrapper
-│   │   └── SettingsPage.tsx        # API key management
-│   │
-│   ├── lib/
-│   │   ├── api.ts                  # REST API client (fetch wrappers)
-│   │   ├── ws.ts                   # WebSocket client + reconnect logic
-│   │   ├── types.ts                # TypeScript interfaces mirroring backend schemas
-│   │   ├── utils.ts                # Utility functions (cn for classname merging)
-│   │   └── useResizablePanels.ts   # Custom hook for resizable panel state
-│   │
-│   └── store/
-│       ├── trace.ts                # Zustand store (traces, spans, graph, time-travel, replay)
-│       ├── playground.ts           # Zustand store (chat, compare, messages)
-│       └── navigation.ts          # Zustand store (page routing)
-│
-├── index.html
+│   │   ├── Sidebar/
+│   │   ├── TraceList/
+│   │   ├── TraceGraph/
+│   │   ├── SpanDetail/
+│   │   ├── TimeTravel/
+│   │   ├── Playground/
+│   │   ├── CostSummaryBar.tsx
+│   │   ├── DemoAgents.tsx
+│   │   └── ErrorBanner.tsx
+│   ├── store/
+│   │   ├── trace.ts
+│   │   ├── playground.ts
+│   │   └── navigation.ts
+│   └── lib/
+│       ├── api.ts
+│       ├── ws.ts
+│       ├── types.ts
+│       ├── useResizablePanels.ts
+│       └── utils.ts
 ├── package.json
-├── vite.config.ts
-└── tsconfig.json
+└── vite.config.ts
 ```
 
 ---
 
-## Layout
+## Routing
 
-The UI uses a sidebar + content panel layout inspired by Linear:
+Routing is handled by React Router (not Zustand page routing).
 
-```
-┌── Sidebar ──┬── Main Content ─────────────────────────┐
-│             │                                          │
-│  Beacon     │  ┌─ Page Content ─────────────────────┐  │
-│             │  │                                     │  │
-│  Dashboard  │  │  (varies by page)                   │  │
-│  Traces  *  │  │                                     │  │
-│  Playground │  │  Traces page uses 3-panel layout:   │  │
-│  Settings   │  │  TraceList | TraceGraph | SpanDetail │  │
-│             │  │                                     │  │
-│             │  └─────────────────────────────────────┘  │
-│   220px     │           bordered, rounded panel         │
-└─────────────┴──────────────────────────────────────────┘
-```
+Defined routes:
+- `/` -> Dashboard
+- `/traces`
+- `/traces/:traceId`
+- `/traces/:traceId/:spanId`
+- `/playground`
+- `/settings`
 
-The main content area is a bordered, rounded container with a subtle shadow (Linear-style inset panel). The sidebar has no border — the contrast between sidebar background and content panel provides visual separation.
-
-### Traces Page (3-panel debugger)
-
-```
-┌──────────────┬──────────────────────────┬──────────────┐
-│              │                          │              │
-│  TraceList   │      TraceGraph          │  SpanDetail  │
-│  (left)      │      (center)            │  (right)     │
-│  ~280px      │      flex-grow           │  ~380px      │
-│              │                          │              │
-│              │                          │              │
-├──────────────┴──────────────────────────┴──────────────┤
-│                    TimeTravel (bottom)  ~48px           │
-└────────────────────────────────────────────────────────┘
-```
-
-All three panels are resizable via drag handles.
-
-### Navigation
-
-Page routing uses a Zustand store (`store/navigation.ts`) — no React Router. Four pages: `dashboard`, `traces`, `playground`, `settings`.
+`Sidebar` handles primary navigation and collapse state.
 
 ---
 
-## Design System
+## Page Responsibilities
 
-See `docs/design-system.md` for the full reference. Key points:
+### Dashboard
+- empty-state onboarding when no traces exist
+- overview cards when traces exist (cost/tokens/duration)
+- demo scenario launcher (`DemoAgents`)
 
-- **Dark-first** — oklch color tokens with blue-purple hue (272)
-- **Inter Variable** font at 13px base
-- **Linear-inspired** — subtle borders, muted backgrounds, accent blue-purple for CTAs
-- All colors are CSS custom properties consumed by Tailwind and shadcn/ui components
+### Traces
+- three-panel debugger layout:
+  - Trace list (left)
+  - graph canvas (center)
+  - span detail (right)
+- draggable resize handles (`useResizablePanels`)
+- optional fullscreen graph mode
+- time-travel slider at bottom
+
+### Playground
+- chat mode (single model, conversation trace)
+- compare mode (multi-model side-by-side)
+- optional system prompt
+- “View in Debugger” navigation for generated trace
+
+### Settings
+- API key management (`openai`, `anthropic`)
+- stats card (`/v1/stats`)
+- clear-all traces action (`DELETE /v1/traces` with `older_than`)
 
 ---
 
 ## State Management (Zustand)
 
-Three Zustand stores:
+### `store/trace.ts`
+Owns:
+- trace list + loading state
+- selected trace/span
+- graph data
+- replay state
+- backend connectivity error message
+- local list filter (`status`, `nameQuery`)
 
-- `store/trace.ts` — Trace, span, graph, time-travel, and replay state
-- `store/playground.ts` — Chat messages, model selection, compare mode
-- `store/navigation.ts` — Page routing (`currentPage`, `navigate()`)
+Actions include:
+- `loadTraces()`
+- `selectTrace(traceId)`
+- `selectSpan(spanId)`
+- `runReplay(spanId, modifiedAttributes)`
+- `appendSpan(span)` for WS events
+- `deleteTrace(traceId)`
 
-`store/trace.ts` holds:
+### `store/playground.ts`
+Owns:
+- message list + conversation state
+- selected model + system prompt
+- compare mode models/results
+- sending/comparing/error states
 
-```typescript
-interface TraceStore {
-  // Trace list
-  traces: TraceSummary[];
-  isLoadingTraces: boolean;
-
-  // Selected trace
-  selectedTraceId: string | null;
-  selectedTrace: TraceDetail | null;
-  isLoadingTrace: boolean;
-
-  // Selected span (for SpanDetail panel)
-  selectedSpanId: string | null;
-  selectedSpan: Span | null;
-
-  // Time-travel
-  timeTravelIndex: number | null;  // null = latest (live)
-
-  // Actions
-  selectTrace: (traceId: string) => Promise<void>;
-  selectSpan: (spanId: string) => void;
-  setTimeTravelIndex: (index: number | null) => void;
-
-  // WebSocket-driven updates
-  appendSpan: (span: Span) => void;
-}
-```
+### `store/navigation.ts`
+Owns only sidebar collapsed state.
 
 ---
 
-## Component Responsibilities
+## Live Updates (WebSocket)
 
-### `TraceList`
+`App.tsx` creates one `BeaconWebSocket` client and subscribes to:
+- `span_created` -> `traceStore.appendSpan`
+- `trace_created` -> `traceStore.prependTrace`
 
-Left panel. Shows all traces sorted newest-first.
-
-Each row shows:
-- Trace name
-- Start time (relative: "2 min ago")
-- Duration
-- Span count
-- Status badge (green = ok, red = error, gray = in progress)
-- Total cost (if LLM calls present)
-
-Click a row → calls `store.selectTrace(traceId)`.
-
-Receives real-time updates via WebSocket: when a new trace appears, it is prepended to the list without a full re-fetch.
-
-### `TraceGraph`
-
-Center panel. Renders the selected trace as an interactive React Flow graph.
-
-**Node types:**
-- `spanNode` — The only custom node type. Renders differently based on `span_type`.
-  - `llm_call` → blue, shows model name + token count
-  - `tool_use` → green, shows tool name
-  - `browser_action` → orange, shows action + URL
-  - `file_operation` → yellow, shows operation + path
-  - `shell_command` → purple, shows command snippet
-  - `agent_step` / `chain` → gray, shows step name
-  - Error status → red border on any node type
-
-**Layout:** Uses `dagre` (via `@dagrejs/dagre`) for automatic top-to-bottom tree layout. The layout is computed once when the trace loads (via `useGraphLayout` hook) and not recomputed on node click.
-
-**Interactions:**
-- Click a node → `store.selectSpan(spanId)`
-- Zoom / pan natively via React Flow
-- Minimap (React Flow built-in) in bottom-right corner
-
-**Time-travel:** When `store.timeTravelIndex` is set, only spans with `start_time <= trace.spans[timeTravelIndex].start_time` are shown. Nodes that are "in the future" are grayed out.
-
-### `SpanDetail`
-
-Right panel. Shows detail for `store.selectedSpan`.
-
-Renders a different sub-component based on `span_type`:
-
-| span_type | Component |
-|-----------|-----------|
-| `llm_call` | `LlmCallDetail` |
-| `tool_use` | `ToolUseDetail` |
-| `browser_action` | `BrowserDetail` |
-| `file_operation` | Generic key-value attributes |
-| `shell_command` | Generic + stdout/stderr code block |
-| `custom` | Generic key-value attributes |
-
-**`LlmCallDetail`** is the most important:
-- Shows prompt (formatted JSON messages)
-- Shows completion
-- Shows tokens, cost, model, finish reason
-- Has an "Edit & Replay" button that opens `PromptEditor`
-
-**`PromptEditor`** (inside SpanDetail for `llm_call` spans):
-- Monaco Editor with `json` language mode for the prompt messages
-- "Replay" button → calls `POST /v1/replay` via API client
-- Shows a diff view of old vs. new completion on success
-- Shows error toast on failure
-
-**`BrowserDetail`:**
-- Shows action type, URL, selector
-- If `browser.screenshot` is present: shows the screenshot image inline
-
-### `TimeTravel`
-
-Bottom panel. Only visible when a trace is selected.
-
-Shows:
-- A horizontal slider across the full width
-- Number of steps: `1` to `trace.spans.length` (ordered by `start_time`)
-- Current step label: span name + type
-- Keyboard shortcuts: Left/Right arrow keys step backward/forward
-
-When the slider moves, `store.setTimeTravelIndex(index)` is called. `TraceGraph` reacts and grays out future nodes.
+WS client behavior:
+- endpoint: `/ws/live` (via Vite WS proxy)
+- exponential reconnect (1s -> 30s max)
+- optional trace subscribe/unsubscribe actions
 
 ---
 
-## API Client (`lib/api.ts`)
+## Graph + Time Travel
 
-All requests go through a thin wrapper around `fetch`. No axios.
+`TraceGraph`:
+- uses React Flow with custom node renderer (`SpanNode`)
+- dagre layout via `useGraphLayout`
+- node click selects span and updates URL
+- node double-click focuses viewport
+- minimap + controls enabled
 
-```typescript
-const BASE_URL = "http://localhost:7474";
-
-export async function getTraces(params?: { limit?: number; offset?: number }): Promise<TracesResponse> {
-  const url = new URL(`${BASE_URL}/v1/traces`);
-  if (params?.limit) url.searchParams.set("limit", String(params.limit));
-  if (params?.offset) url.searchParams.set("offset", String(params.offset));
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`GET /v1/traces failed: ${res.status}`);
-  return res.json();
-}
-
-export async function getTrace(traceId: string): Promise<TraceDetail> { ... }
-export async function getTraceGraph(traceId: string): Promise<GraphData> { ... }
-export async function getSpan(spanId: string): Promise<Span> { ... }
-export async function replaySpan(spanId: string, modifiedAttributes: Record<string, unknown>): Promise<ReplayResult> { ... }
-```
+`TimeTravel`:
+- slider range `0..nodes.length`
+- dims future nodes based on selected step
+- keyboard step controls: left/right arrows
 
 ---
 
-## WebSocket Client (`lib/ws.ts`)
+## Span Detail + Replay
 
-Connects to `ws://localhost:7474/ws/live`. Implements:
-- Auto-reconnect with exponential backoff (1s, 2s, 4s, max 30s)
-- Dispatches events to the Zustand store
+`SpanDetail` dispatches by `span_type`:
+- `llm_call` -> `LlmCallDetail`
+- `tool_use` -> `ToolUseDetail`
+- `browser_action` -> `BrowserDetail`
+- fallback -> `GenericDetail`
 
-```typescript
-class BeaconWebSocket {
-  connect(): void { ... }
-  subscribeToTrace(traceId: string): void { ... }
-  onSpanCreated(handler: (span: Span) => void): void { ... }
-  onTraceCreated(handler: (trace: TraceSummary) => void): void { ... }
-}
-```
+`LlmCallDetail` includes:
+- provider/model badges
+- token and cost metrics
+- prompt/completion display
+- tool call inspection (`llm.tool_calls`)
+- replay panel with Monaco editor (`PromptEditor`)
 
----
-
-## TypeScript Types (`lib/types.ts`)
-
-Must mirror the backend Pydantic schemas exactly. When the backend schemas change, update this file too.
-
-```typescript
-export type SpanType =
-  | "llm_call" | "tool_use" | "agent_step"
-  | "browser_action" | "file_operation" | "shell_command"
-  | "chain" | "custom";
-
-export type SpanStatus = "ok" | "error" | "unset";
-
-export interface Span {
-  span_id: string;
-  trace_id: string;
-  parent_span_id: string | null;
-  span_type: SpanType;
-  name: string;
-  status: SpanStatus;
-  error_message: string | null;
-  start_time: number;
-  end_time: number | null;
-  duration_ms: number | null;
-  attributes: Record<string, unknown>;
-}
-
-export interface TraceSummary {
-  trace_id: string;
-  name: string;
-  start_time: number;
-  end_time: number | null;
-  duration_ms: number | null;
-  span_count: number;
-  status: SpanStatus;
-  total_cost_usd: number;
-  total_tokens: number;
-  tags: Record<string, string>;
-}
-
-// ... more types
-```
+Replay call:
+- `POST /v1/replay`
+- request uses `modified_attributes`
 
 ---
 
-## shadcn/ui Policy
+## API Layer (`src/lib/api.ts`)
 
-- **Never `npm install` a component library.** Use shadcn/ui copy-paste instead.
-- Run `npx shadcn@latest add button` to add a component.
-- All shadcn components live in `src/components/ui/`. Do not edit them.
-- For custom components, create them outside `src/components/ui/`.
+- base URL is relative: `BASE_URL = "/v1"`
+- Vite proxies `/v1` -> backend in dev
+- all requests use shared `apiFetch<T>()` error normalization
+
+Available functions include:
+- traces/spans/replay
+- settings key CRUD
+- playground chat/compare
+- demo scenario list/run
+- stats/search
+- delete single/all traces
+
+---
+
+## Vite Proxy
+
+From `vite.config.ts`:
+- `/v1` -> `http://localhost:7474`
+- `/ws` -> `ws://localhost:7474`
+
+This keeps frontend code environment-agnostic in dev.
+
+---
+
+## Design System
+
+Tokens and styling live in:
+- `src/index.css`
+- `docs/design-system.md`
+
+Current UI is dark-first with oklch tokens and thin-border density.
 
 ---
 
@@ -361,33 +225,8 @@ export interface TraceSummary {
 ```bash
 cd frontend
 npm install
-npm run dev       # Dev server at http://localhost:5173
-npm run build     # Production build
-npm run typecheck # tsc --noEmit
-npm run lint      # eslint
+npm run dev
+npm run build
+npm run lint
+npm run typecheck
 ```
-
----
-
-## Key Dependencies
-
-| Package | Version | Purpose |
-|---------|---------|---------|
-| `react` | 19.x | UI framework |
-| `@xyflow/react` | latest | Graph visualization (React Flow) |
-| `@monaco-editor/react` | latest | Code editor for prompt editing |
-| `zustand` | 5.x | Global state management |
-| `@dagrejs/dagre` | latest | Graph layout algorithm |
-| `tailwindcss` | 4.x | Utility CSS |
-| `typescript` | 5.x | Type safety |
-| `vite` | 7.x | Dev server + build |
-| `lucide-react` | latest | Icon library |
-
----
-
-## Performance Notes
-
-- **Never fetch all spans on load.** Use `/v1/traces/{id}/graph` which returns a pre-computed graph structure.
-- **Virtualize the TraceList** if it exceeds 100 items (use `@tanstack/react-virtual`).
-- **Don't re-render the entire graph on every WebSocket message.** React Flow handles this via memoized node/edge arrays.
-- **Lazy-load Monaco Editor.** It's large. Use `React.lazy` + `Suspense` for the `PromptEditor` component.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -62,7 +62,7 @@ Running `python sdk/examples/hello_world.py` with the backend running produces a
 - [x] Write example: `sdk/examples/langchain_agent.py`
 
 **Frontend**
-- [x] Initialize `frontend/` with Vite, React 18, TypeScript
+- [x] Initialize `frontend/` with Vite, React 19, TypeScript
 - [x] Configure Tailwind CSS + shadcn/ui (`init`)
 - [x] Add required shadcn components: Button, Badge, Separator, ScrollArea
 - [x] Implement `lib/types.ts` (all TypeScript interfaces)
@@ -165,7 +165,7 @@ A developer can `pip install beacon-sdk`, follow the README, and have a working 
 
 **Layout & Navigation**
 - [x] Replace tab-bar navigation with persistent 220px sidebar (Dashboard, Traces, Playground, Settings)
-- [x] Add Zustand-based page routing (`store/navigation.ts`)
+- [x] Add route-driven navigation (React Router) and keep Zustand state for sidebar/UI controls
 - [x] Linear-style inset content panel (bordered, rounded, shadowed)
 
 **Pages**

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,73 +1,48 @@
-# React + TypeScript + Vite
+# Beacon Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React + TypeScript UI for Beacon.
 
-Currently, two official plugins are available:
+## Run
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+From repo root:
 
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+make install
+make dev-frontend
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Or from `frontend/`:
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
+npm run dev
 ```
+
+Frontend runs on `http://localhost:5173` and proxies:
+- `/v1` -> backend `http://localhost:7474`
+- `/ws` -> backend websocket `ws://localhost:7474`
+
+## Scripts
+
+```bash
+npm run dev
+npm run build
+npm run lint
+npm run typecheck
+npm run preview
+```
+
+## Key Source Files
+
+- `src/App.tsx` - root layout + route definitions
+- `src/pages/` - Dashboard, Traces, Playground, Settings
+- `src/store/` - Zustand stores
+- `src/lib/api.ts` - REST client
+- `src/lib/ws.ts` - WebSocket client
+- `src/components/` - feature components
+- `src/index.css` - theme tokens/styles
+
+## Notes
+
+- Do not edit `src/components/ui/` unless intentionally modifying shared shadcn primitives.
+- API contracts are documented in `../docs/api-contracts.md`.


### PR DESCRIPTION
## Summary
This PR performs a full documentation audit and syncs docs with the current codebase behavior across backend, SDK, and frontend.

### Updated
- `README.md`
- `AGENTS.md`
- `docs/api-contracts.md`
- `docs/architecture.md`
- `docs/backend.md`
- `docs/frontend.md`
- `docs/sdk.md`
- `docs/data-model.md`
- `docs/contributing.md`
- `docs/conventions.md`
- `docs/roadmap.md` (accuracy tweaks)
- `frontend/README.md`
- `sdk/README.md`

## What changed
- Brought API docs in sync with active routes: spans/traces/replay/settings/playground/demo/search/stats + websocket events.
- Updated architecture/backend/frontend/sdk docs to reflect current implementation details and runtime behavior.
- Corrected stale assumptions (routing model, React version references, SDK behavior/config, schema wording).
- Refreshed contributor and agent-facing guidance to avoid missing workflow-critical instructions.

## Validation
- Manual second-pass review was run after edits to ensure no engineer/agent-critical instructions were accidentally removed.
- No application code changes; documentation-only PR.